### PR TITLE
Fix_UrlShortenerOptions_Registration_Bug

### DIFF
--- a/samples/UrlShortener.AspNetCore/Migrations/20230908144903_init.Designer.cs
+++ b/samples/UrlShortener.AspNetCore/Migrations/20230908144903_init.Designer.cs
@@ -11,8 +11,8 @@ using UrlShortener.AspNetCore.Models;
 namespace UrlShortener.AspNetCore.Migrations
 {
     [DbContext(typeof(BaseDbContext))]
-    [Migration("20230904174627_initi")]
-    partial class initi
+    [Migration("20230908144903_init")]
+    partial class init
     {
         /// <inheritdoc />
         protected override void BuildTargetModel(ModelBuilder modelBuilder)

--- a/samples/UrlShortener.AspNetCore/Migrations/20230908144903_init.cs
+++ b/samples/UrlShortener.AspNetCore/Migrations/20230908144903_init.cs
@@ -5,7 +5,7 @@
 namespace UrlShortener.AspNetCore.Migrations
 {
     /// <inheritdoc />
-    public partial class initi : Migration
+    public partial class init : Migration
     {
         /// <inheritdoc />
         protected override void Up(MigrationBuilder migrationBuilder)

--- a/samples/UrlShortener.AspNetCore/Models/CustomShortUrlEntity.cs
+++ b/samples/UrlShortener.AspNetCore/Models/CustomShortUrlEntity.cs
@@ -4,6 +4,6 @@ namespace UrlShortener.AspNetCore.Models
 {
     public class CustomShortUrlEntity : ShortUrlEntity
     {
-        public string CustomProperty { get; set; } = default!;
+        public string? CustomProperty { get; set; }
     }
 }

--- a/src/UrlShortener.Core/UrlShortenerMiddleware.cs
+++ b/src/UrlShortener.Core/UrlShortenerMiddleware.cs
@@ -2,6 +2,7 @@
 // See LICENSE in the project root for license information.
 
 using Microsoft.AspNetCore.Http;
+using Microsoft.Extensions.Options;
 using System;
 using System.Threading.Tasks;
 
@@ -10,25 +11,24 @@ namespace UrlShortener.Core;
 public class UrlShortenerMiddleware<TUrlShortener> where TUrlShortener : class
 {
     private RequestDelegate _nextDelegate;
-    private readonly UrlShortenerOptions _urlShortenerOptions;
 
-    public UrlShortenerMiddleware(RequestDelegate nextDelegate,
-        UrlShortenerOptions urlShortenerOptions)
+    public UrlShortenerMiddleware(RequestDelegate nextDelegate)
     {
         _nextDelegate = nextDelegate;
-        _urlShortenerOptions = urlShortenerOptions;
     }
 
-    public async Task Invoke(HttpContext context, UrlShortenerManager<TUrlShortener> urlShortenerManager)
+    public async Task Invoke(HttpContext context, 
+        UrlShortenerManager<TUrlShortener> urlShortenerManager, 
+        IOptions<UrlShortenerOptions> urlShortenerOptions)
     {
         var path = context.Request.Path.Value;
-        if (_urlShortenerOptions.UseUrlShortenerInTheSameDomain)
+        if (urlShortenerOptions.Value.UseUrlShortenerInTheSameDomain)
         {
-            if (path.StartsWith(_urlShortenerOptions.ShortUrlPrefix))
+            if (path.StartsWith(urlShortenerOptions.Value.ShortUrlPrefix))
             {
                 string url = $"{context.Request.Scheme}://{context.Request.Host.Value}{path}";
                 var longUrl = await urlShortenerManager.GetLongUrlAsync(url);
-                context.Response.Redirect(longUrl, permanent: _urlShortenerOptions.UsePermanentRedirect);
+                context.Response.Redirect(longUrl, permanent: urlShortenerOptions.Value.UsePermanentRedirect);
             }
             else
             {
@@ -38,12 +38,11 @@ public class UrlShortenerMiddleware<TUrlShortener> where TUrlShortener : class
         else
         {
             // so this domain is specified for url shortener only
-
             var host = context.Request.Host;
-            if (_urlShortenerOptions.DomainName.Equals(host.Value))
+            if (urlShortenerOptions.Value.DomainName.Equals(host.Value))
             {
                 var longUrl = await urlShortenerManager.GetLongUrlAsync(path);
-                context.Response.Redirect(longUrl, permanent: _urlShortenerOptions.UsePermanentRedirect);
+                context.Response.Redirect(longUrl, permanent: urlShortenerOptions.Value.UsePermanentRedirect);
             }
             else
             {

--- a/src/UrlShortener.Core/UrlShortenerRedirectionBuilderExtensions.cs
+++ b/src/UrlShortener.Core/UrlShortenerRedirectionBuilderExtensions.cs
@@ -24,12 +24,7 @@ public static class UrlShortenerRedirectionBuilderExtensions
     {
         if(app == null)
             throw new ArgumentNullException(nameof(app));
-
-        var shortenerOptions = app.ApplicationServices.GetService<UrlShortenerOptions>();
-        if(shortenerOptions ==null) 
-            throw new ArgumentNullException(nameof(shortenerOptions));
-
-        app.UseMiddleware<UrlShortenerMiddleware<TUrlShortener>>(shortenerOptions);
+        app.UseMiddleware<UrlShortenerMiddleware<TUrlShortener>>();
 
         return app;
     }

--- a/src/UrlShortener.Core/UrlShortenerServiceCollectionExtensions.cs
+++ b/src/UrlShortener.Core/UrlShortenerServiceCollectionExtensions.cs
@@ -22,9 +22,13 @@ public static class UrlShortenerServiceCollectionExtensions
     public static UrlShortenerBuilder AddUrlShortener<TUrlShortener>(this IServiceCollection services, Action<UrlShortenerOptions> options = null)
         where TUrlShortener : class
     {
-        UrlShortenerOptions o = new UrlShortenerOptions();
-        services.AddSingleton(o);
-        options?.Invoke(o);
+        //UrlShortenerOptions o = new UrlShortenerOptions();
+        //services.AddSingleton(o);
+        //options?.Invoke(o);
+        if (options == null)
+            services.AddOptions();
+        else
+            services.Configure(options);
 
         services.TryAddScoped<UrlShortenerManager<TUrlShortener>>();
         return new UrlShortenerBuilder(typeof(TUrlShortener), services);


### PR DESCRIPTION
When you create a custom configure for AddUrlShortener the server can't recognize the custom values, instead of that the server still read the default value.